### PR TITLE
Add option for blog posts subfolder structure change

### DIFF
--- a/config.md
+++ b/config.md
@@ -11,6 +11,12 @@ prepath = "ft-academic-resume"
 hasplotly = false
 hasmermaid = false
 
+# Set global variable `dateformat` to `"post"`, `"yearmonth"`, or `"year"`
+# The expected file structures are
+# - `"yearmonth"`: posts/YYYY/MM/name-of-post.md
+# - `"year"`: posts/YYYY/name-of-post.md
+# - `"post"`: posts/name-of-post.md
+dateformat = "yearmonth"
 # RSS setup
 website_title = "Franklin Template"
 website_descr = "Example website using Franklin"

--- a/utils.jl
+++ b/utils.jl
@@ -193,18 +193,37 @@ end
 # List of recent posts #
 # -------------------- #
 
+# Set global variable `dateformat` to `"post"`, `"yearmonth"`, or `"year"`
+# The expected file structures are
+# - `"yearmonth"`: posts/YYYY/MM/name-of-post.md
+# - `"year"`: posts/YYYY/name-of-post.md
+# - `"post"`: posts/name-of-post.md
+
 function all_posts()
-    # expected file structure here is posts/YYYY/MM/name-of-post.md
     posts = Pair{String,Date}[]
+    dateformat = globvar("dateformat"; default="yearmonth")
     for (root, _, files) in walkdir(joinpath(Franklin.FOLDER_PATH[], "posts"))
         for file in files
             endswith(file, ".md") || continue
             ppath = joinpath(root, file)
             endswith(ppath, joinpath("posts", "index.md")) && continue
-            tmp, fn = splitdir(ppath)
-            tmp, mm = splitdir(tmp)
-            tmp, yy = splitdir(tmp)
-            rpath = joinpath("posts", yy, mm, splitext(fn)[1])
+            spath = splitpath(ppath)
+            post = first(splitext(pop!(spath)))
+            if dateformat == "yearmonth"
+                mm = pop!(spath)
+                yy = pop!(spath)
+                rpath = joinpath("posts", yy, mm, post)
+            elseif dateformat == "year"
+                mm = "01"
+                yy = pop!(spath)
+                rpath = joinpath("posts", yy, post)
+            elseif dateformat == "post"
+                mm = yy = "01"
+                rpath = joinpath("posts", post)
+            else
+                error("Dateformat $dateformat not supported, use 'post', 'year', or 'yearmonth'")
+            end
+            
             date = pagevar(rpath, "pubdate")
             isnothing(date) && (date = Date("$yy-$mm-01"))
             push!(posts, rpath => date)


### PR DESCRIPTION
I prefer blog post url to be just `posts/year/name-of-post` rather than having the month included. This is a small edit that allows using a global variable to set the expected folder structure to include year and month (current behavior, default), just year, or just `posts/name-of-post`. 

This is unsolicited complexity, I realize, so totally fine if you don't want to include it in the template, but it wasn't much extra effort to make it a PR