### PR TITLE
Fix images on recent posts

### DIFF
--- a/posts/2020/07/literate.md
+++ b/posts/2020/07/literate.md
@@ -2,7 +2,7 @@
 pubdate = Date("2020-07-10")
 title = "Using Literate"
 showall = true
-img = "assets/img/post2.jpg"
+img = "assets/img/post2.png"
 +++
 
 [Literate.jl](https://github.com/fredrikekre/Literate.jl) is a convenient package that allows you to write scripts in Julia and convert them to markdown pages or Jupyter notebooks.

--- a/utils.jl
+++ b/utils.jl
@@ -277,7 +277,7 @@ function show_posts(posts; byyear=false)
                 </div>
               </div>
               <div class=ml-3>
-                <a href="/$rpath"><img src="$imgpath" alt="$title"></a>
+              $(ifelse(isempty(imgpath), "", """<a href="/$rpath"><img src="$imgpath" alt="$title"></a>"""))
               </div>
             </div>""")
     end


### PR DESCRIPTION
2 things:

1. The image for `posts/literate.md` was pointing to `post2.jpg`, instead of `post2.png`.
2. I added some logic so that posts without an `img` property just have a blank instead of a broken-link thumbnail - that is, 

![image](https://user-images.githubusercontent.com/3502975/139731389-6e71b376-256f-4422-925a-c98714d43165.png)

becomes

![image](https://user-images.githubusercontent.com/3502975/139731450-69c5faee-1224-47ee-84c1-0468e43e7359.png)
